### PR TITLE
[Work in Progress] Convert krunvm into a library

### DIFF
--- a/src/changevm.rs
+++ b/src/changevm.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use crate::{ArgMatches, KrunvmConfig, APP_NAME};
+use crate::{ArgMatches, KrunvmConfig, LIBRARY_NAME};
 
 use super::list::printvm;
 use super::utils::{parse_mapped_ports, parse_mapped_volumes};
@@ -114,6 +114,6 @@ pub fn changevm(cfg: &mut KrunvmConfig, matches: &ArgMatches) {
     println!();
 
     if cfg_changed {
-        confy::store(APP_NAME, &cfg).unwrap();
+        confy::store(LIBRARY_NAME, &cfg).unwrap();
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 Red Hat, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ArgMatches, KrunvmConfig, APP_NAME};
+use crate::{ArgMatches, KrunvmConfig, LIBRARY_NAME};
 
 pub fn config(cfg: &mut KrunvmConfig, matches: &ArgMatches) {
     let mut cfg_changed = false;
@@ -40,7 +40,7 @@ pub fn config(cfg: &mut KrunvmConfig, matches: &ArgMatches) {
     }
 
     if cfg_changed {
-        confy::store(APP_NAME, &cfg).unwrap();
+        confy::store(LIBRARY_NAME, &cfg).unwrap();
     }
 
     println!("Global configuration:");

--- a/src/create.rs
+++ b/src/create.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use std::process::Command;
 
 use super::utils::{mount_container, parse_mapped_ports, parse_mapped_volumes, umount_container};
-use crate::{ArgMatches, KrunvmConfig, VmConfig, APP_NAME};
+use crate::{ArgMatches, KrunvmConfig, VmConfig, LIBRARY_NAME};
 
 fn fix_resolv_conf(rootfs: &str, dns: &str) -> Result<(), std::io::Error> {
     let resolvconf_dir = format!("{}/etc/", rootfs);
@@ -98,7 +98,7 @@ pub fn create(cfg: &mut KrunvmConfig, matches: &ArgMatches) {
         Ok(output) => output,
         Err(err) => {
             if err.kind() == std::io::ErrorKind::NotFound {
-                println!("{} requires buildah to manage the OCI images, and it wasn't found on this system.", APP_NAME);
+                println!("{} requires buildah to manage the OCI images, and it wasn't found on this system.", LIBRARY_NAME);
             } else {
                 println!("Error executing buildah: {}", err.to_string());
             }
@@ -137,7 +137,7 @@ pub fn create(cfg: &mut KrunvmConfig, matches: &ArgMatches) {
     umount_container(&cfg, &vmcfg).unwrap();
 
     cfg.vmconfig_map.insert(name.clone(), vmcfg);
-    confy::store(APP_NAME, cfg).unwrap();
+    confy::store(LIBRARY_NAME, cfg).unwrap();
 
     println!("Lightweight VM created with name: {}", name);
 }

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -1,7 +1,7 @@
 // Copyright 2021 Red Hat, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ArgMatches, KrunvmConfig, APP_NAME};
+use crate::{ArgMatches, KrunvmConfig, LIBRARY_NAME};
 
 use super::utils::{remove_container, umount_container};
 
@@ -19,5 +19,5 @@ pub fn delete(cfg: &mut KrunvmConfig, matches: &ArgMatches) {
     umount_container(&cfg, &vmcfg).unwrap();
     remove_container(&cfg, &vmcfg).unwrap();
 
-    confy::store(APP_NAME, &cfg).unwrap();
+    confy::store(LIBRARY_NAME, &cfg).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,154 @@
+// Copyright 2021 Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+#[cfg(target_os = "macos")]
+use std::fs::File;
+#[cfg(target_os = "macos")]
+use std::io::{self, Read, Write};
+
+use clap::ArgMatches;
+use serde_derive::{Deserialize, Serialize};
+#[cfg(target_os = "macos")]
+use text_io::read;
+
+#[allow(unused)]
+pub mod bindings;
+pub mod changevm;
+pub mod config;
+pub mod create;
+pub mod delete;
+pub mod list;
+pub mod start;
+pub mod utils;
+
+const LIBRARY_NAME: &str = "krunvm";
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct VmConfig {
+    name: String,
+    cpus: u32,
+    mem: u32,
+    container: String,
+    workdir: String,
+    dns: String,
+    mapped_volumes: HashMap<String, String>,
+    mapped_ports: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct KrunvmConfig {
+    version: u8,
+    default_cpus: u32,
+    default_mem: u32,
+    default_dns: String,
+    storage_volume: String,
+    vmconfig_map: HashMap<String, VmConfig>,
+}
+
+impl Default for KrunvmConfig {
+    fn default() -> KrunvmConfig {
+        KrunvmConfig {
+            version: 1,
+            default_cpus: 2,
+            default_mem: 1024,
+            default_dns: "1.1.1.1".to_string(),
+            storage_volume: String::new(),
+            vmconfig_map: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn check_case_sensitivity(volume: &str) -> Result<bool, io::Error> {
+    let first_path = format!("{}/krunvm_test", volume);
+    let second_path = format!("{}/krunVM_test", volume);
+    {
+        let mut first = File::create(&first_path)?;
+        first.write_all(b"first")?;
+    }
+    {
+        let mut second = File::create(&second_path)?;
+        second.write_all(b"second")?;
+    }
+    let mut data = String::new();
+    {
+        let mut test = File::open(&first_path)?;
+
+        test.read_to_string(&mut data)?;
+    }
+    if data == "first" {
+        let _ = std::fs::remove_file(first_path);
+        let _ = std::fs::remove_file(second_path);
+        Ok(true)
+    } else {
+        let _ = std::fs::remove_file(first_path);
+        Ok(false)
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn check_volume(cfg: &mut KrunvmConfig) {
+    if !cfg.storage_volume.is_empty() {
+        return;
+    }
+
+    println!(
+        "
+On macOS, krunvm requires a dedicated, case-sensitive volume.
+You can easily create such volume by executing something like
+this on another terminal:
+
+diskutil apfs addVolume disk3 \"Case-sensitive APFS\" krunvm
+
+NOTE: APFS volume creation is a non-destructive action that
+doesn't require a dedicated disk nor \"sudo\" privileges. The
+new volume will share the disk space with the main container
+volume.
+"
+    );
+    loop {
+        print!("Please enter the mountpoint for this volume [/Volumes/krunvm]: ");
+        io::stdout().flush().unwrap();
+        let answer: String = read!("{}\n");
+
+        let volume = if answer.is_empty() {
+            "/Volumes/krunvm".to_string()
+        } else {
+            answer.to_string()
+        };
+
+        print!("Checking volume... ");
+        match check_case_sensitivity(&volume) {
+            Ok(res) => {
+                if res {
+                    println!("success.");
+                    println!("The volume has been configured. Please execute krunvm again");
+                    cfg.storage_volume = volume;
+                    confy::store(LIBRARY_NAME, cfg).unwrap();
+                    std::process::exit(-1);
+                } else {
+                    println!("failed.");
+                    println!("This volume failed the case sensitivity test.");
+                }
+            }
+            Err(err) => {
+                println!("error.");
+                println!("There was an error running the test: {}", err);
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn check_unshare() {
+    let uid = unsafe { libc::getuid() };
+    if uid != 0
+        && std::env::vars()
+            .find(|(key, _)| key == "BUILDAH_ISOLATION")
+            .is_none()
+    {
+        println!("Please re-run krunvm inside a \"buildah unshare\" session");
+        std::process::exit(-1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,160 +1,12 @@
 // Copyright 2021 Red Hat, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-#[cfg(target_os = "macos")]
-use std::fs::File;
-#[cfg(target_os = "macos")]
-use std::io::{self, Read, Write};
-
-use clap::{crate_version, App, Arg, ArgMatches};
-use serde_derive::{Deserialize, Serialize};
-#[cfg(target_os = "macos")]
-use text_io::read;
-
-#[allow(unused)]
-mod bindings;
-mod changevm;
-mod config;
-mod create;
-mod delete;
-mod list;
-mod start;
-mod utils;
+use clap::{crate_version, App, Arg};
 
 const APP_NAME: &str = "krunvm";
 
-#[derive(Default, Debug, Serialize, Deserialize)]
-pub struct VmConfig {
-    name: String,
-    cpus: u32,
-    mem: u32,
-    container: String,
-    workdir: String,
-    dns: String,
-    mapped_volumes: HashMap<String, String>,
-    mapped_ports: HashMap<String, String>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct KrunvmConfig {
-    version: u8,
-    default_cpus: u32,
-    default_mem: u32,
-    default_dns: String,
-    storage_volume: String,
-    vmconfig_map: HashMap<String, VmConfig>,
-}
-
-impl Default for KrunvmConfig {
-    fn default() -> KrunvmConfig {
-        KrunvmConfig {
-            version: 1,
-            default_cpus: 2,
-            default_mem: 1024,
-            default_dns: "1.1.1.1".to_string(),
-            storage_volume: String::new(),
-            vmconfig_map: HashMap::new(),
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn check_case_sensitivity(volume: &str) -> Result<bool, io::Error> {
-    let first_path = format!("{}/krunvm_test", volume);
-    let second_path = format!("{}/krunVM_test", volume);
-    {
-        let mut first = File::create(&first_path)?;
-        first.write_all(b"first")?;
-    }
-    {
-        let mut second = File::create(&second_path)?;
-        second.write_all(b"second")?;
-    }
-    let mut data = String::new();
-    {
-        let mut test = File::open(&first_path)?;
-
-        test.read_to_string(&mut data)?;
-    }
-    if data == "first" {
-        let _ = std::fs::remove_file(first_path);
-        let _ = std::fs::remove_file(second_path);
-        Ok(true)
-    } else {
-        let _ = std::fs::remove_file(first_path);
-        Ok(false)
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn check_volume(cfg: &mut KrunvmConfig) {
-    if !cfg.storage_volume.is_empty() {
-        return;
-    }
-
-    println!(
-        "
-On macOS, krunvm requires a dedicated, case-sensitive volume.
-You can easily create such volume by executing something like
-this on another terminal:
-
-diskutil apfs addVolume disk3 \"Case-sensitive APFS\" krunvm
-
-NOTE: APFS volume creation is a non-destructive action that
-doesn't require a dedicated disk nor \"sudo\" privileges. The
-new volume will share the disk space with the main container
-volume.
-"
-    );
-    loop {
-        print!("Please enter the mountpoint for this volume [/Volumes/krunvm]: ");
-        io::stdout().flush().unwrap();
-        let answer: String = read!("{}\n");
-
-        let volume = if answer.is_empty() {
-            "/Volumes/krunvm".to_string()
-        } else {
-            answer.to_string()
-        };
-
-        print!("Checking volume... ");
-        match check_case_sensitivity(&volume) {
-            Ok(res) => {
-                if res {
-                    println!("success.");
-                    println!("The volume has been configured. Please execute krunvm again");
-                    cfg.storage_volume = volume;
-                    confy::store(APP_NAME, cfg).unwrap();
-                    std::process::exit(-1);
-                } else {
-                    println!("failed.");
-                    println!("This volume failed the case sensitivity test.");
-                }
-            }
-            Err(err) => {
-                println!("error.");
-                println!("There was an error running the test: {}", err);
-            }
-        }
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn check_unshare() {
-    let uid = unsafe { libc::getuid() };
-    if uid != 0
-        && std::env::vars()
-            .find(|(key, _)| key == "BUILDAH_ISOLATION")
-            .is_none()
-    {
-        println!("Please re-run krunvm inside a \"buildah unshare\" session");
-        std::process::exit(-1);
-    }
-}
-
 fn main() {
-    let mut cfg: KrunvmConfig = confy::load(APP_NAME).unwrap();
+    let mut cfg: krunvm::KrunvmConfig = confy::load(APP_NAME).unwrap();
 
     let mut app = App::new("krunvm")
         .version(crate_version!())
@@ -354,22 +206,22 @@ fn main() {
     let matches = app.clone().get_matches();
 
     #[cfg(target_os = "macos")]
-    check_volume(&mut cfg);
+    krunvm::check_volume(&mut cfg);
     #[cfg(target_os = "linux")]
-    check_unshare();
+    krunvm::check_unshare();
 
     if let Some(ref matches) = matches.subcommand_matches("changevm") {
-        changevm::changevm(&mut cfg, matches);
+        krunvm::changevm::changevm(&mut cfg, matches);
     } else if let Some(ref matches) = matches.subcommand_matches("config") {
-        config::config(&mut cfg, matches);
+        krunvm::config::config(&mut cfg, matches);
     } else if let Some(ref matches) = matches.subcommand_matches("create") {
-        create::create(&mut cfg, matches);
+        krunvm::create::create(&mut cfg, matches);
     } else if let Some(ref matches) = matches.subcommand_matches("delete") {
-        delete::delete(&mut cfg, matches);
+        krunvm::delete::delete(&mut cfg, matches);
     } else if let Some(ref matches) = matches.subcommand_matches("list") {
-        list::list(&cfg, matches);
+        krunvm::list::list(&cfg, matches);
     } else if let Some(ref matches) = matches.subcommand_matches("start") {
-        start::start(&cfg, matches);
+        krunvm::start::start(&cfg, matches);
     } else {
         app.print_long_help().unwrap();
         println!();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
 
-use crate::{KrunvmConfig, VmConfig, APP_NAME};
+use crate::{KrunvmConfig, VmConfig, LIBRARY_NAME};
 
 pub fn parse_mapped_ports(port_matches: Vec<&str>) -> HashMap<String, String> {
     let mut mapped_ports = HashMap::new();
@@ -100,7 +100,7 @@ pub fn mount_container(cfg: &KrunvmConfig, vmcfg: &VmConfig) -> Result<String, s
         Ok(output) => output,
         Err(err) => {
             if err.kind() == std::io::ErrorKind::NotFound {
-                println!("{} requires buildah to manage the OCI images, and it wasn't found on this system.", APP_NAME);
+                println!("{} requires buildah to manage the OCI images, and it wasn't found on this system.", LIBRARY_NAME);
             } else {
                 println!("Error executing buildah: {}", err.to_string());
             }
@@ -148,7 +148,7 @@ pub fn umount_container(cfg: &KrunvmConfig, vmcfg: &VmConfig) -> Result<(), std:
         Ok(output) => output,
         Err(err) => {
             if err.kind() == std::io::ErrorKind::NotFound {
-                println!("{} requires buildah to manage the OCI images, and it wasn't found on this system.", APP_NAME);
+                println!("{} requires buildah to manage the OCI images, and it wasn't found on this system.", LIBRARY_NAME);
             } else {
                 println!("Error executing buildah: {}", err.to_string());
             }
@@ -189,7 +189,7 @@ pub fn remove_container(cfg: &KrunvmConfig, vmcfg: &VmConfig) -> Result<(), std:
         Ok(output) => output,
         Err(err) => {
             if err.kind() == std::io::ErrorKind::NotFound {
-                println!("{} requires buildah to manage the OCI images, and it wasn't found on this system.", APP_NAME);
+                println!("{} requires buildah to manage the OCI images, and it wasn't found on this system.", LIBRARY_NAME);
             } else {
                 println!("Error executing buildah: {}", err.to_string());
             }


### PR DESCRIPTION
## Description

This PR is a work-in-progress to convert krunvm into a library in order to enable its use as a crate in
other projects.

## Known Issues

- This implementation has a few flaws presently since it began as a copy/paste of `main.rs` contents into the new `lib.rs` file.
  -These are known and should be addressed.
- Uses of `std::process:exit` would have to be replaced with `Result` type returns.

## Next Steps

1. Convert all library code to return errors rather than panic or exit
2. Convert clap "matches" into a library-based struct to be portable

## Notes to Maintainers

While this PR is a draft, please feel free to leave comments and review!

## Question to Maintainers

@slp: if the purpose of `krunvm` is to only be a CLI, should developers who want to use the API use `libkrun` (and `libkrunfw`) instead?