### PR TITLE
Add Security and C-O-C docs

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,3 @@
+## The krunvm Project Community Code of Conduct
+
+The krunvm Project follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/master/CODE-OF-CONDUCT.md).

--- a/Security.md
+++ b/Security.md
@@ -1,0 +1,4 @@
+## Security and Disclosure Information Policy for the krunvm Project
+
+The krunvm Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/master/SECURITY.md) for the Containers Projects.
+


### PR DESCRIPTION
Adds the SECURITY.md and CODE-OF-CONDUCT.md templates that point
to the main one in containers common.  If you do not like these,
please supply your own.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>