### PR TITLE
Fix build failure on macOS due to missing Inspect case

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,6 +55,9 @@ pub fn get_buildah_args(cfg: &KrunvmConfig, cmd: BuildahCommand) -> Vec<String> 
             args.push("--os".to_string());
             args.push("linux".to_string());
         }
+        BuildahCommand::Inspect => {
+            args.push("inspect".to_string());
+        }
         BuildahCommand::Mount => {
             args.push("mount".to_string());
         }


### PR DESCRIPTION
Add the missing `Inspect` case in the macOS configuration.

Fixes: #24

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>