### PR TITLE
macos: Add missing BuildahCommand

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,6 +55,9 @@ pub fn get_buildah_args(cfg: &KrunvmConfig, cmd: BuildahCommand) -> Vec<String> 
             args.push("--os".to_string());
             args.push("linux".to_string());
         }
+        BuildahCommand::Inspect => {
+            args.push("inspect".to_string());
+        }
         BuildahCommand::Mount => {
             args.push("mount".to_string());
         }


### PR DESCRIPTION
Commit "2285182aa254df8af86fca8f3e6e46a9c657418c" introduced
BuildahCommand::Inspect without adding the appropiate case for the
match in the macOS-specific code. Fix it now.

(It'd be nice having a macOS/ARM64 CI runner)

Fixes: #24
Signed-off-by: Sergio Lopez <slp@sinrega.org>