### PR TITLE
Restrict the number of values of "-p" and "-v"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "krunvm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "confy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krunvm"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 description = "Create microVMs from OCI images"
 repository = "https://github.com/containers/krunvm"

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,8 @@ fn main() {
                         .short("v")
                         .help("Volume in form \"host_path:guest_path\" to be exposed to the guest")
                         .takes_value(true)
-                        .multiple(true),
+                        .multiple(true)
+                        .number_of_values(1),
                 )
                 .arg(
                     Arg::with_name("remove-ports")
@@ -208,7 +209,8 @@ fn main() {
                         .short("p")
                         .help("Port in format \"host_port:guest_port\" to be exposed to the host")
                         .takes_value(true)
-                        .multiple(true),
+                        .multiple(true)
+                        .number_of_values(1),
                 )
                 .arg(
                     Arg::with_name("new-name")
@@ -279,7 +281,8 @@ fn main() {
                         .short("v")
                         .help("Volume in form \"host_path:guest_path\" to be exposed to the guest")
                         .takes_value(true)
-                        .multiple(true),
+                        .multiple(true)
+                        .number_of_values(1),
                 )
                 .arg(
                     Arg::with_name("port")
@@ -287,7 +290,8 @@ fn main() {
                         .short("p")
                         .help("Port in format \"host_port:guest_port\" to be exposed to the host")
                         .takes_value(true)
-                        .multiple(true),
+                        .multiple(true)
+                        .number_of_values(1),
                 )
                 .arg(
                     Arg::with_name("name")


### PR DESCRIPTION
With clap, "multiple(true)" implies that an argument may appear morethan once, but also that each time can declare multiple values. This behavior clobbers the positional argument IMAGE.
    
To prevent this, declare a limit of 1 value per occurrence.