### PR TITLE
Makefile: Remove INIT_BINARY because there is no such thing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 OS = $(shell uname -s)
 KRUNVM_RELEASE = target/release/krunvm
 KRUNVM_DEBUG = target/debug/krunvm
-INIT_BINARY = init/init
 
 ifeq ($(PREFIX),)
     PREFIX := /usr/local


### PR DESCRIPTION
It looks like the variable was just copied from libkrun.