### PR TITLE
Resolve clippy warnings and use correct types in bindings

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,22 +1,24 @@
 // Copyright 2021 Red Hat, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use libc::c_char;
+
 #[link(name = "krun")]
 extern "C" {
     pub fn krun_set_log_level(level: u32) -> i32;
     pub fn krun_create_ctx() -> i32;
     pub fn krun_free_ctx(ctx: u32) -> i32;
     pub fn krun_set_vm_config(ctx: u32, num_vcpus: u8, ram_mib: u32) -> i32;
-    pub fn krun_set_root(ctx: u32, root_path: *const i8) -> i32;
-    pub fn krun_set_mapped_volumes(ctx: u32, mapped_volumes: *const *const i8) -> i32;
-    pub fn krun_set_port_map(ctx: u32, port_map: *const *const i8) -> i32;
-    pub fn krun_set_workdir(ctx: u32, workdir_path: *const i8) -> i32;
+    pub fn krun_set_root(ctx: u32, root_path: *const c_char) -> i32;
+    pub fn krun_set_mapped_volumes(ctx: u32, mapped_volumes: *const *const c_char) -> i32;
+    pub fn krun_set_port_map(ctx: u32, port_map: *const *const c_char) -> i32;
+    pub fn krun_set_workdir(ctx: u32, workdir_path: *const c_char) -> i32;
     pub fn krun_set_exec(
         ctx: u32,
-        exec_path: *const i8,
-        argv: *const *const i8,
-        envp: *const *const i8,
+        exec_path: *const c_char,
+        argv: *const *const c_char,
+        envp: *const *const c_char,
     ) -> i32;
-    pub fn krun_set_env(ctx: u32, envp: *const *const i8) -> i32;
+    pub fn krun_set_env(ctx: u32, envp: *const *const c_char) -> i32;
     pub fn krun_start_enter(ctx: u32) -> i32;
 }

--- a/src/changevm.rs
+++ b/src/changevm.rs
@@ -13,7 +13,7 @@ pub fn changevm(cfg: &mut KrunvmConfig, matches: &ArgMatches) {
 
     let name = matches.value_of("NAME").unwrap();
 
-    let mut vmcfg = if let Some(new_name) = matches.value_of("new-name") {
+    let vmcfg = if let Some(new_name) = matches.value_of("new-name") {
         if cfg.vmconfig_map.contains_key(new_name) {
             println!("A VM with name {} already exists", new_name);
             std::process::exit(-1);

--- a/src/create.rs
+++ b/src/create.rs
@@ -67,7 +67,7 @@ fn export_container_config(
 }
 
 pub fn create(cfg: &mut KrunvmConfig, matches: &ArgMatches) {
-    let mut cpus = match matches.value_of("cpus") {
+    let cpus = match matches.value_of("cpus") {
         Some(c) => match c.parse::<u32>() {
             Err(_) => {
                 println!("Invalid value for \"cpus\"");


### PR DESCRIPTION
bindings were using i8 instead of c_char for C string pointers, but the types are defined as c_char in libkrun.

There were a lot of unnecessary casts from i8 to c_char according to clippy because on x86_64 they are the same type.
(The casts were necessary on ARM, because c_char is unsigned on ARM).