### PR TITLE
Add inspect command

### DIFF
--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -1,0 +1,52 @@
+// Copyright 2021 Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+use crate::{
+    utils::{get_buildah_args, BuildahCommand},
+    KrunvmConfig,
+};
+use clap::Args;
+
+/// Run `buildah inspect` on an existing microVM
+#[derive(Args, Debug)]
+pub struct InspectCmd {
+    /// Name of the microVM to be inspected
+    name: String,
+}
+
+impl InspectCmd {
+    pub fn run(self, cfg: &mut KrunvmConfig) {
+        let vmcfg = match cfg.vmconfig_map.get(&self.name) {
+            None => {
+                println!("No VM found with that name");
+                std::process::exit(-1);
+            }
+            Some(vmcfg) => vmcfg,
+        };
+
+        let mut args = get_buildah_args(cfg, BuildahCommand::Inspect);
+        args.push(vmcfg.container.clone());
+
+        let output = Command::new("buildah")
+            .args(&args)
+            .stderr(std::process::Stdio::inherit())
+            .output();
+
+        if output.is_err() {
+            println!("Failed to inspect VM");
+            std::process::exit(1);
+        }
+
+        let output = match String::from_utf8(output.unwrap().stdout) {
+            Err(err) => {
+                println!("Failed to parse `buildah inspect` output: #{err}.");
+                std::process::exit(1);
+            }
+            Ok(output) => output,
+        };
+
+        println!("{output}");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,6 +2,7 @@ mod changevm;
 mod config;
 mod create;
 mod delete;
+mod inspect;
 mod list;
 mod start;
 
@@ -9,5 +10,6 @@ pub use changevm::ChangeVmCmd;
 pub use config::ConfigCmd;
 pub use create::CreateCmd;
 pub use delete::DeleteCmd;
+pub use inspect::InspectCmd;
 pub use list::ListCmd;
 pub use start::StartCmd;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,9 @@ use std::fs::File;
 #[cfg(target_os = "macos")]
 use std::io::{self, Read, Write};
 
-use crate::commands::{ChangeVmCmd, ConfigCmd, CreateCmd, DeleteCmd, ListCmd, StartCmd};
+use crate::commands::{
+    ChangeVmCmd, ConfigCmd, CreateCmd, DeleteCmd, InspectCmd, ListCmd, StartCmd,
+};
 use clap::{Parser, Subcommand};
 use serde_derive::{Deserialize, Serialize};
 #[cfg(target_os = "macos")]
@@ -159,6 +161,7 @@ struct Cli {
 enum Command {
     Start(StartCmd),
     Create(CreateCmd),
+    Inspect(InspectCmd),
     List(ListCmd),
     Delete(DeleteCmd),
     #[command(name = "changevm")]
@@ -176,6 +179,7 @@ fn main() {
     check_unshare();
 
     match cli_args.command {
+        Command::Inspect(cmd) => cmd.run(&mut cfg),
         Command::Start(cmd) => cmd.run(&cfg),
         Command::Create(cmd) => cmd.run(&mut cfg),
         Command::List(cmd) => cmd.run(&cfg),


### PR DESCRIPTION
This adds a `krunvm inspect` command that runs `buildah inspect` under the hood, so users can find information about the VM, such as the image metadata (e.g. image name and digest) or mount point.

This allows, for example, creating a microVM and later only conditionally recreating it with a new image if an update is available.

## Example

```sh
$ krunvm create nginx:1.27.2-alpine --name nginx-test
...
$ krunvm inspect nginx-test | jq -r .FromImage
docker.io/library/nginx:1.27.2-alpine
```