### PR TITLE
start: Only map volumes if required on macOS

### DIFF
--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -112,6 +112,9 @@ fn map_volumes(_ctx: u32, vmcfg: &VmConfig, rootfs: &str) {
 
 #[cfg(target_os = "macos")]
 fn map_volumes(ctx: u32, vmcfg: &VmConfig, rootfs: &str) {
+    if vmcfg.mapped_volumes.is_empty() {
+        return;
+    }
     let mut volumes = Vec::new();
     for (host_path, guest_path) in vmcfg.mapped_volumes.iter() {
         let full_guest = format!("{}{}", &rootfs, guest_path);


### PR DESCRIPTION
In issue #67, it was reported that VM creation on macOS always fails with the message: "Error setting VM mapped volumes". [^1] It appears krun always calls `krun_set_mapped_volumes` even if the user has not configured any volumes. That krun library function was disabled in Feb 2024 by commit 186083df9. [^2] Based on the commit message, it sounds like virtio-fs devices will be the preferred way to implement mapped volumes going forward.

For now, we can at least avoid calling the deprecated function if the user has not configured any mapped volumes. That will obviously not fix the krun feature, but it makes krunvm usable on macOS.

References

1. https://github.com/containers/krunvm/issues/67
2. libkrun commit 186083df9faf704e2b431d90b1ed147363aca004